### PR TITLE
fix #11: プロフィール説明更新時のavatar/banner削除を修正

### DIFF
--- a/update_profile.py
+++ b/update_profile.py
@@ -29,16 +29,34 @@ def update_profile(username, password, description):
     try:
         client = Client()
         client.login(username, password)
-        profile = client.app.bsky.actor.get_profile({'actor': client.me.did})
+
+        # 既存のプロフィールレコードを取得し、avatar/banner/displayName 等を保持する。
+        # get_profile はビューを返すだけで avatar/banner の blob 参照を含まないため、
+        # レコード本体を get_record で取得して description のみ差し替える。
+        try:
+            existing = client.com.atproto.repo.get_record({
+                'repo': client.me.did,
+                'collection': 'app.bsky.actor.profile',
+                'rkey': 'self',
+            })
+            record = existing.value
+        except Exception:
+            record = None
+
+        if record is not None:
+            record.description = description
+        else:
+            # レコードが存在しない場合は新規作成
+            record = {
+                '$type': 'app.bsky.actor.profile',
+                'description': description,
+            }
+
         client.com.atproto.repo.put_record({
             'repo': client.me.did,
             'collection': 'app.bsky.actor.profile',
             'rkey': 'self',
-            'record': {
-                '$type': 'app.bsky.actor.profile',
-                'displayName': profile.display_name,
-                'description': description,
-            }
+            'record': record,
         })
     except Exception as e:
         print(f"Error: Failed to update profile: {e}", file=sys.stderr)


### PR DESCRIPTION
## 概要

`update_profile.py` で説明文(description)を更新するとプロフィール画像(avatar)が削除される不具合を修正する。

Closes #11

## 原因

`put_record` で `app.bsky.actor.profile` レコードを書き込む際、`displayName` と `description` のみを指定していたため、レコード全体が上書きされ、既存の `avatar`・`banner` 等のフィールド（blob参照）が失われていた。`get_profile` はビューを返すだけで blob 参照を含まないため、再設定もできていなかった。

## 修正内容

`com.atproto.repo.get_record`（collection=`app.bsky.actor.profile`, rkey=`self`）で**既存レコード本体**を取得し、`description` のみを差し替えて `put_record` する方式に変更。これにより `avatar`・`banner`・`displayName` 等の既存フィールドを保持する。レコードが存在しない場合は description のみで新規作成にフォールバックする。

## テスト計画

- [ ] avatar/banner を設定済みのアカウントで `update_profile.py` を実行し、説明文が更新され、かつ avatar/banner が保持されることを確認する
- [ ] displayName が変更されないことを確認する
- [ ] プロフィールレコード未作成のアカウントで実行し、説明文付きで新規作成されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)