### PR TITLE
fix #13: 投稿中の @handle / URL をリンク(facet)化する

### DIFF
--- a/post_message.py
+++ b/post_message.py
@@ -1,8 +1,16 @@
 #!/usr/bin/python3
 import csv
+import re
 import sys
 import time
-from atproto import Client
+from atproto import Client, client_utils
+
+# メッセージ中の @handle と URL を検出するための正規表現。
+# handle: 英数字・ハイフン・ドットから成り、語境界(直前が行頭または空白等)で始まるもの。
+TOKEN_RE = re.compile(
+    r'(?P<mention>(?<![\w@.])@[A-Za-z0-9][A-Za-z0-9.-]*[A-Za-z0-9])'
+    r'|(?P<url>https?://[^\s]+)'
+)
 
 POST_CSV = 'post.csv'
 POST_RETRY = 3
@@ -25,11 +33,37 @@ def read_post_csv():
     return credentials
 
 
+def build_rich_text(client, message):
+    # メッセージを @handle / URL / 通常テキストに分割し、TextBuilder を組み立てる。
+    # メンションはハンドルを DID に解決して mention facet を付与する。
+    # URL は link facet を付与する。解決に失敗した場合はプレーンテキストとして扱う。
+    tb = client_utils.TextBuilder()
+    pos = 0
+    for m in TOKEN_RE.finditer(message):
+        if m.start() > pos:
+            tb.text(message[pos:m.start()])
+        token = m.group(0)
+        if m.lastgroup == 'mention':
+            handle = token[1:]  # 先頭の '@' を除く
+            try:
+                did = client.com.atproto.identity.resolve_handle({'handle': handle}).did
+                tb.mention(token, did)
+            except Exception as e:
+                print(f"Warning: Cannot resolve handle '{handle}': {e}", file=sys.stderr)
+                tb.text(token)
+        else:  # url
+            tb.link(token, token)
+        pos = m.end()
+    if pos < len(message):
+        tb.text(message[pos:])
+    return tb
+
+
 def post_message(username, password, message):
     try:
         client = Client()
         client.login(username, password)
-        client.send_post(message)
+        client.send_post(build_rich_text(client, message))
     except Exception as e:
         print(f"Error: Failed to post: {e}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## 概要

`post_message.py` で投稿したメッセージ中の `@handle`（メンション）や URL がリンクにならない不具合を修正する。

Closes #13

## 原因

`client.send_post(message)` にプレーン文字列を渡していたため、投稿レコードに facet（リンク情報）が付与されていなかった。BlueSky の投稿はアプリ側で自動リンク化されず、投稿作成時に facet を埋め込む必要がある（bio は自動検出されるが投稿は別挙動）。

## 修正内容

- `build_rich_text()` を追加し、メッセージを `@handle` / URL / 通常テキストに分割
- `@handle` は `com.atproto.identity.resolve_handle` でハンドルを DID に解決し **mention facet** を付与
- `http(s)://` の URL は **link facet** を付与
- ハンドルの DID 解決に失敗した場合は警告を出力し、プレーンテキストとして投稿を継続
- `send_post` に `TextBuilder` を渡すよう変更

## テスト

- トークナイザの正規表現を検証（メンション・URL を検出、メールアドレス形式の `@` は誤検出しない）
- `python3 -m py_compile` で構文確認

## レビュー時の補足

- ハンドル→DID 解決にはネットワークと認証が必要なため、実アカウントへのライブ投稿テストは未実施。
- メンション検出は語境界（直前が行頭/空白等）で始まる `@英数字.-` を対象とし、メールアドレス等の埋め込み `@` は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)